### PR TITLE
Implemented RGB support for custom items leather armor (#663) [skip release]

### DIFF
--- a/api/mythicdrops.api
+++ b/api/mythicdrops.api
@@ -291,12 +291,30 @@ public abstract interface class com/tealcube/minecraft/bukkit/mythicdrops/api/it
 	public abstract fun getMaterial ()Lorg/bukkit/Material;
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getRepairCost ()I
+	public abstract fun getRgb ()Lcom/tealcube/minecraft/bukkit/mythicdrops/api/items/CustomItem$Rgb;
 	public abstract fun isAddDefaultAttributes ()Z
 	public abstract fun isBroadcastOnFind ()Z
 	public abstract fun isEnchantmentsRemovableByGrindstone ()Z
 	public abstract fun isGlow ()Z
 	public abstract fun isUnbreakable ()Z
 	public abstract fun toItemStack (Lcom/tealcube/minecraft/bukkit/mythicdrops/api/enchantments/CustomEnchantmentRegistry;)Lorg/bukkit/inventory/ItemStack;
+}
+
+public final class com/tealcube/minecraft/bukkit/mythicdrops/api/items/CustomItem$Rgb {
+	public fun <init> (III)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (III)Lcom/tealcube/minecraft/bukkit/mythicdrops/api/items/CustomItem$Rgb;
+	public static synthetic fun copy$default (Lcom/tealcube/minecraft/bukkit/mythicdrops/api/items/CustomItem$Rgb;IIIILjava/lang/Object;)Lcom/tealcube/minecraft/bukkit/mythicdrops/api/items/CustomItem$Rgb;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlue ()I
+	public final fun getGreen ()I
+	public final fun getRed ()I
+	public fun hashCode ()I
+	public final fun isEmpty ()Z
+	public final fun toColor ()Lorg/bukkit/Color;
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/tealcube/minecraft/bukkit/mythicdrops/api/items/CustomItemManager : com/tealcube/minecraft/bukkit/mythicdrops/api/managers/WeightedManager {

--- a/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/api/items/CustomItem.kt
+++ b/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/api/items/CustomItem.kt
@@ -79,7 +79,7 @@ interface CustomItem : Weighted {
         }
 
         fun isEmpty(): Boolean {
-            return red == 0 && green == 0 && blue == 0
+            return red == -1 && green == -1 && blue == -1
         }
     }
 }

--- a/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/api/items/CustomItem.kt
+++ b/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/api/items/CustomItem.kt
@@ -69,7 +69,6 @@ interface CustomItem : Weighted {
     )
     fun toItemStack(customEnchantmentRegistry: CustomEnchantmentRegistry): ItemStack
 
-
     data class Rgb(
         val red: Int,
         val green: Int,

--- a/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/api/items/CustomItem.kt
+++ b/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/api/items/CustomItem.kt
@@ -54,6 +54,7 @@ interface CustomItem : Weighted {
     val isEnchantmentsRemovableByGrindstone: Boolean
     val isAddDefaultAttributes: Boolean
     val hdbId: String
+    val rgb: String
 
     /**
      * Use the CustomItemFactory acquired from ProductionLine instead.

--- a/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/api/items/CustomItem.kt
+++ b/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/api/items/CustomItem.kt
@@ -25,6 +25,7 @@ import com.tealcube.minecraft.bukkit.mythicdrops.api.attributes.MythicAttribute
 import com.tealcube.minecraft.bukkit.mythicdrops.api.enchantments.CustomEnchantmentRegistry
 import com.tealcube.minecraft.bukkit.mythicdrops.api.enchantments.MythicEnchantment
 import com.tealcube.minecraft.bukkit.mythicdrops.api.weight.Weighted
+import org.bukkit.Color
 import org.bukkit.Material
 import org.bukkit.inventory.ItemFlag
 import org.bukkit.inventory.ItemStack
@@ -54,7 +55,7 @@ interface CustomItem : Weighted {
     val isEnchantmentsRemovableByGrindstone: Boolean
     val isAddDefaultAttributes: Boolean
     val hdbId: String
-    val rgb: String
+    val rgb: Rgb
 
     /**
      * Use the CustomItemFactory acquired from ProductionLine instead.
@@ -67,4 +68,19 @@ interface CustomItem : Weighted {
         )
     )
     fun toItemStack(customEnchantmentRegistry: CustomEnchantmentRegistry): ItemStack
+
+
+    data class Rgb(
+        val red: Int,
+        val green: Int,
+        val blue: Int
+    ) {
+        fun toColor(): Color {
+            return Color.fromRGB(red, green, blue)
+        }
+
+        fun isEmpty(): Boolean {
+            return red == 0 && green == 0 && blue == 0
+        }
+    }
 }

--- a/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/commands/CustomCreateCommand.kt
+++ b/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/commands/CustomCreateCommand.kt
@@ -36,6 +36,7 @@ import com.tealcube.minecraft.bukkit.mythicdrops.sendMythicMessage
 import com.tealcube.minecraft.bukkit.mythicdrops.utils.AirUtil
 import org.bukkit.ChatColor
 import org.bukkit.entity.Player
+import org.bukkit.inventory.meta.LeatherArmorMeta
 
 @CommandAlias("mythicdrops|md")
 internal class CustomCreateCommand : BaseCommand() {
@@ -96,6 +97,12 @@ internal class CustomCreateCommand : BaseCommand() {
             mythicDropsPlugin.customItemYAML.set("$name.enchantments.$enchKey.minimum-level", it.minimumLevel)
             mythicDropsPlugin.customItemYAML.set("$name.enchantments.$enchKey.maximum-level", it.maximumLevel)
         }
+
+        if (itemMeta is LeatherArmorMeta) {
+            val color = itemMeta.color
+            mythicDropsPlugin.customItemYAML.set("$name.rgb", "${color.red},${color.green},${color.blue}")
+        }
+
         mythicDropsPlugin.customItemYAML.save()
     }
 }

--- a/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/commands/CustomCreateCommand.kt
+++ b/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/commands/CustomCreateCommand.kt
@@ -100,7 +100,9 @@ internal class CustomCreateCommand : BaseCommand() {
 
         if (itemMeta is LeatherArmorMeta) {
             val color = itemMeta.color
-            mythicDropsPlugin.customItemYAML.set("$name.rgb", "${color.red},${color.green},${color.blue}")
+            mythicDropsPlugin.customItemYAML.set("$name.rgb.red", color.red)
+            mythicDropsPlugin.customItemYAML.set("$name.rgb.green", color.green)
+            mythicDropsPlugin.customItemYAML.set("$name.rgb.blue", color.blue)
         }
 
         mythicDropsPlugin.customItemYAML.save()

--- a/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/items/MythicCustomItem.kt
+++ b/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/items/MythicCustomItem.kt
@@ -67,7 +67,8 @@ internal data class MythicCustomItem(
     override val repairCost: Int = DEFAULT_REPAIR_COST,
     override val isEnchantmentsRemovableByGrindstone: Boolean = true,
     override val isAddDefaultAttributes: Boolean = false,
-    override val hdbId: String = ""
+    override val hdbId: String = "",
+    override val rgb: String = ""
 ) : CustomItem {
     companion object {
         fun fromConfigurationSection(configurationSection: ConfigurationSection, key: String): MythicCustomItem {
@@ -120,7 +121,8 @@ internal data class MythicCustomItem(
                 repairCost = configurationSection.getInt("repair-cost", DEFAULT_REPAIR_COST),
                 isEnchantmentsRemovableByGrindstone = isEnchantmentsRemovableByGrindstone,
                 isAddDefaultAttributes = isAddDefaultAttributes,
-                hdbId = configurationSection.getNonNullString("hdb-id")
+                hdbId = configurationSection.getNonNullString("hdb-id"),
+                rgb = configurationSection.getNonNullString("rgb")
             )
         }
 

--- a/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/items/MythicCustomItem.kt
+++ b/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/items/MythicCustomItem.kt
@@ -68,7 +68,7 @@ internal data class MythicCustomItem(
     override val isEnchantmentsRemovableByGrindstone: Boolean = true,
     override val isAddDefaultAttributes: Boolean = false,
     override val hdbId: String = "",
-    override val rgb: String = ""
+    override val rgb: CustomItem.Rgb = CustomItem.Rgb(0, 0, 0)
 ) : CustomItem {
     companion object {
         fun fromConfigurationSection(configurationSection: ConfigurationSection, key: String): MythicCustomItem {
@@ -122,7 +122,11 @@ internal data class MythicCustomItem(
                 isEnchantmentsRemovableByGrindstone = isEnchantmentsRemovableByGrindstone,
                 isAddDefaultAttributes = isAddDefaultAttributes,
                 hdbId = configurationSection.getNonNullString("hdb-id"),
-                rgb = configurationSection.getNonNullString("rgb")
+                rgb = CustomItem.Rgb(
+                    red = configurationSection.getInt("rgb.red"),
+                    green = configurationSection.getInt("rgb.blue"),
+                    blue = configurationSection.getInt("rgb.green")
+                )
             )
         }
 

--- a/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/items/MythicCustomItem.kt
+++ b/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/items/MythicCustomItem.kt
@@ -68,7 +68,7 @@ internal data class MythicCustomItem(
     override val isEnchantmentsRemovableByGrindstone: Boolean = true,
     override val isAddDefaultAttributes: Boolean = false,
     override val hdbId: String = "",
-    override val rgb: CustomItem.Rgb = CustomItem.Rgb(0, 0, 0)
+    override val rgb: CustomItem.Rgb = CustomItem.Rgb(-1, -1, -1)
 ) : CustomItem {
     companion object {
         fun fromConfigurationSection(configurationSection: ConfigurationSection, key: String): MythicCustomItem {

--- a/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/items/factories/MythicCustomItemFactory.kt
+++ b/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/items/factories/MythicCustomItemFactory.kt
@@ -37,8 +37,10 @@ import io.pixeloutlaw.minecraft.spigot.mythicdrops.itemFlags
 import io.pixeloutlaw.minecraft.spigot.mythicdrops.mythicDropsCustomItem
 import io.pixeloutlaw.minecraft.spigot.mythicdrops.setPersistentDataString
 import io.pixeloutlaw.minecraft.spigot.plumbing.lib.ItemAttributes
+import org.bukkit.Color
 import org.bukkit.Material
 import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.LeatherArmorMeta
 
 /**
  * Implementation of [CustomItemFactory] that enables the implementation of [CustomItem] to change
@@ -88,6 +90,14 @@ internal class MythicCustomItemFactory(
         }
         itemStack.itemFlags = customItem.itemFlags
         itemStack.setPersistentDataString(mythicDropsCustomItem, customItem.name)
+
+        if (customItem.rgb.isNotEmpty() && itemStack.itemMeta is LeatherArmorMeta) {
+            val meta = itemStack.itemMeta as LeatherArmorMeta
+            val colors = customItem.rgb.split(",")
+            meta.setColor(Color.fromRGB(colors[0].toInt(), colors[1].toInt(), colors[2].toInt()))
+            itemStack.itemMeta = meta
+        }
+
         return itemStack
     }
 }

--- a/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/items/factories/MythicCustomItemFactory.kt
+++ b/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/items/factories/MythicCustomItemFactory.kt
@@ -37,7 +37,6 @@ import io.pixeloutlaw.minecraft.spigot.mythicdrops.itemFlags
 import io.pixeloutlaw.minecraft.spigot.mythicdrops.mythicDropsCustomItem
 import io.pixeloutlaw.minecraft.spigot.mythicdrops.setPersistentDataString
 import io.pixeloutlaw.minecraft.spigot.plumbing.lib.ItemAttributes
-import org.bukkit.Color
 import org.bukkit.Material
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.LeatherArmorMeta

--- a/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/items/factories/MythicCustomItemFactory.kt
+++ b/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/items/factories/MythicCustomItemFactory.kt
@@ -91,10 +91,9 @@ internal class MythicCustomItemFactory(
         itemStack.itemFlags = customItem.itemFlags
         itemStack.setPersistentDataString(mythicDropsCustomItem, customItem.name)
 
-        if (customItem.rgb.isNotEmpty() && itemStack.itemMeta is LeatherArmorMeta) {
+        if (!customItem.rgb.isEmpty() && itemStack.itemMeta is LeatherArmorMeta) {
             val meta = itemStack.itemMeta as LeatherArmorMeta
-            val colors = customItem.rgb.split(",")
-            meta.setColor(Color.fromRGB(colors[0].toInt(), colors[1].toInt(), colors[2].toInt()))
+            meta.setColor(customItem.rgb.toColor())
             itemStack.itemMeta = meta
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds the ability to set rgb values for leather armor
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes not allowing you to use rgb values in leather armor
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This needs more testing. Did simple item spawning in game and it worked fine
## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/21014720/163861508-a7b6894c-5ae7-4c9f-852b-e71351ef1567.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ X] Breaking change (fix or feature that would cause existing functionality to change)
- (I have no idea if this is a breaking change or not)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ X?] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ X] All new and existing tests passed.
