### PR TITLE
check for custom model data before creation

### DIFF
--- a/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/items/MythicCustomItem.kt
+++ b/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/items/MythicCustomItem.kt
@@ -138,7 +138,11 @@ internal data class MythicCustomItem(
             headDatabaseAdapter: HeadDatabaseAdapter
         ): MythicCustomItem {
             val hasCustomModelData = itemStack.hasCustomModelData()
-            val customModelData = itemStack.customModelData ?: 0
+            val customModelData = if (hasCustomModelData) {
+                itemStack.customModelData ?: 0
+            } else {
+                0
+            }
             val attributeModifiersFromItems = itemStack.getAttributeModifiers().asMap() ?: emptyMap()
             val attributes =
                 attributeModifiersFromItems.flatMap { entry ->


### PR DESCRIPTION
fixes an issue with `/md customcreate` throwing exceptions
when there is no custom model data on the item.