### PR TITLE
fix #704 - vanilla items cannot be renamed

### DIFF
--- a/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/MythicDropsPlugin.kt
+++ b/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/MythicDropsPlugin.kt
@@ -463,7 +463,8 @@ class MythicDropsPlugin : JavaPlugin(), MythicDrops, MythicKoinComponent {
             .registerEvents(
                 AnvilListener(
                     MythicDropsApi.mythicDrops.settingsManager,
-                    MythicDropsApi.mythicDrops.tierManager
+                    MythicDropsApi.mythicDrops.tierManager,
+                    MythicDropsApi.mythicDrops.socketExtenderTypeManager
                 ),
                 this
             )

--- a/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/inventories/AnvilListener.kt
+++ b/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/inventories/AnvilListener.kt
@@ -22,6 +22,7 @@
 package com.tealcube.minecraft.bukkit.mythicdrops.inventories
 
 import com.tealcube.minecraft.bukkit.mythicdrops.api.settings.SettingsManager
+import com.tealcube.minecraft.bukkit.mythicdrops.api.socketing.SocketExtenderTypeManager
 import com.tealcube.minecraft.bukkit.mythicdrops.api.tiers.TierManager
 import com.tealcube.minecraft.bukkit.mythicdrops.chatColorize
 import com.tealcube.minecraft.bukkit.mythicdrops.utils.GemUtil
@@ -37,7 +38,8 @@ import org.bukkit.inventory.ItemStack
 
 internal class AnvilListener(
     private val settingsManager: SettingsManager,
-    private val tierManager: TierManager
+    private val tierManager: TierManager,
+    private val socketExtenderTypeManager: SocketExtenderTypeManager
 ) : Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     fun onPrepareAnvilEvent(event: PrepareAnvilEvent) {
@@ -53,7 +55,9 @@ internal class AnvilListener(
     }
 
     private fun handleEarlySocketExtenderCheck(event: PrepareAnvilEvent) {
-        val anyAreSocketExtenders = event.inventory.anyDisplayName(settingsManager.socketingSettings.items.socketExtender.name.chatColorize())
+        val anyAreSocketExtenders = socketExtenderTypeManager.get().any {
+            event.inventory.anyDisplayName(it.socketExtenderStyleChatColorized)
+        }
         if (anyAreSocketExtenders) {
             event.result = ItemStack(Material.AIR)
         }


### PR DESCRIPTION
This fixes issue #704, where the display names of non-renamed items can be a blank string, instead of null. When paired with the default config, especially for the `socketExtender`, which has a blank display name, this causes the anvil to be unusable for vanilla items. We can resolve this by checking for a blank string, and ignoring it.